### PR TITLE
iOS 16 beta: Return empty string when plist value is nil

### DIFF
--- a/Jitterbug/JBHostDevice.m
+++ b/Jitterbug/JBHostDevice.m
@@ -369,7 +369,11 @@ error:
 
 static NSString *plist_dict_get_nsstring(plist_t dict, const char *key) {
     plist_t *value = plist_dict_get_item(dict, key);
-    NSString *string = [NSString stringWithUTF8String:plist_get_string_ptr(value, NULL)];
+    const char* cString = plist_get_string_ptr(value, NULL);
+    if (cString == NULL) {
+        return @"";
+    }
+    NSString *string = [NSString stringWithUTF8String:cString];
     return string;
 }
 


### PR DESCRIPTION
When parsing an entry in the plist, was getting a NULL entry for the `Container`, and ended up crashing. Doing an `[NSString stringWithUTF8String:]` with a NULL value results in a crash.  Not sure why or how this is happening, or whether this is specific to iOS 16 beta 1, but I had to make the following code change to get this to work under iOS 16 beta 1.

The good news is that I was able to pair my device using jitterbugpair and use the iOS 16.0 developer disk image, and was able to try a couple JIT enabled apps (flycast and Play!).

Please feel free to suggest edits and/or additional insight.